### PR TITLE
fix test author data

### DIFF
--- a/cmd/aozora-collector/main_test.go
+++ b/cmd/aozora-collector/main_test.go
@@ -16,7 +16,7 @@ func TestFindEntries(t *testing.T) {
 			w.Write([]byte(`
             <table summary="作家データ">
             <tr><td class="header">作家名：</td><td><font size="+2">テスト 太郎</font></td></tr>
-            <tr><td class="header">作家名読み：</td><td>テスト 太郎</td></tr>
+            <tr><td class="header">作家名読み：</td><td>てすと たろう</td></tr>
             <tr><td class="header">ローマ字表記：</td><td>Test, Taro</td></tr>
             </table>
             <ol>
@@ -30,9 +30,12 @@ func TestFindEntries(t *testing.T) {
 			token := pat.FindStringSubmatch(r.URL.String())
 			w.Write([]byte(fmt.Sprintf(`
             <table summary="作家データ">
-            <tr><td class="header">作家名：</td><td><font size="+2">テスト 太郎</font></td></tr>
-            <tr><td class="header">作家名読み：</td><td>テスト 太郎</td></tr>
+            <tbody>
+            <tr><td class="header">分類：</td><td>著者</td></tr>
+            <tr><td class="header">作家名：</td><td><a href="../../index_pages/person999999.html">テスト 太郎</a></td></tr>
+            <tr><td class="header">作家名読み：</td><td>てすと たろう</td></tr>
             <tr><td class="header">ローマ字表記：</td><td>Test, Taro</td></tr>
+            </tbody>
             </table>
             <table border="1" summary="ダウンロードデータ" class="download">
             <tr>


### PR DESCRIPTION
## Problem

The test server response at TestFindEntries seems to be wrong and unit test is accidentally passing.

### Details

Test server returns same `<table summary="作家データ">` data in both `if` (author page response) and `else` (author's title page response) patterns.

https://github.com/mattn/aozora-search/blob/9bb4d86d5d33fe28085c21c745bf24bc19c96792/cmd/aozora-collector/main_test.go#L17-L21

https://github.com/mattn/aozora-search/blob/9bb4d86d5d33fe28085c21c745bf24bc19c96792/cmd/aozora-collector/main_test.go#L32-L36

But _aozora_ seems to be returning different structure of `<table summary="作家データ">` data between author page https://www.aozora.gr.jp/index_pages/person879.html and author's title page https://www.aozora.gr.jp/cards/000879/card73.html

Actually, an author's title page https://www.aozora.gr.jp/cards/000879/card73.html is returning following data.

```html
<table summary="作家データ">
<tbody><tr><td class="header">分類：</td><td>著者</td></tr>
<tr><td class="header">作家名：</td><td><a href="../../index_pages/person879.html">芥川 竜之介</a></td></tr>
<tr><td class="header">作家名読み：</td><td>あくたがわ りゅうのすけ</td></tr>
<tr><td class="header">ローマ字表記：</td><td>Akutagawa, Ryunosuke</td></tr>
<tr><td class="header">生年：</td><td>1892-03-01</td></tr>
<tr><td class="header">没年：</td><td>1927-07-24</td></tr>
<tr><td class="header">人物について：</td><td>東大在学中に同人雑誌「新思潮」に発表した「鼻」を漱石が激賞し、文壇で活躍するようになる。王朝もの、近世初期のキリシタン文学、江戸時代の人物・事件、明治の文明開化期など、さまざまな時代の歴史的文献に題材をとり、スタイルや文体を使い分けたたくさんの短編小説を書いた。体力の衰えと「ぼんやりした不安」から自殺。その死は大正時代文学の終焉と重なっている。<br><a href="http://ja.wikipedia.org/" target="_blank"><img align="middle" src="../images/wikipedia_logo_rounded.png" width="110" height="32" border="0" alt="wikipediaアイコン"></a>「<a href="http://ja.wikipedia.org/wiki/%E8%8A%A5%E5%B7%9D%E7%AB%9C%E4%B9%8B%E4%BB%8B" target="_blank">芥川龍之介</a>」<br></td></tr>
</tbody></table>
```

There are two different points.
* There is a "分類:" `<tr><td>` before "作家名" `<tr><td>`.
* "作家名読み" seems to be written in ひらがな.

So, it seems that current test data is just passing the test by referring the `td` in "作家名読み" which includes the same string as author name "テスト 太郎".

## Expected test data

Test server should return `else` pattern response with following `<table summary="作家データ">`
```html
				<table summary="作家データ">
				<tbody>
				<tr><td class="header">分類:</td> <td>著者</td></tr>
				<tr><td class="header">作家名:</td><td><a href="../../index_pages/person999999.html">テスト 太郎</a></td></tr>
				<tr><td class="header">作家名読み:</td><td>てすと たろう</td></tr>
				<tr><td class="header">ローマ字表記:</td><td>Test, Taro</td></tr>
				</tbody>
				</table>
```
and "作家名読み" in `if` pattern should also be "てすと たろう".

I checked and confirmed that the unit test can pass with this test data at my local env.

Thank you